### PR TITLE
Fix let: Symbol’s value as variable is void: const

### DIFF
--- a/themes/kaolin-mono-dark-theme.el
+++ b/themes/kaolin-mono-dark-theme.el
@@ -28,7 +28,7 @@
    (builtin     spring-green9)
    (functions   builtin)
    (const       builtin)
-   (var         const)
+   (var         builtin)
    (type        spring-green7)
 
    (comment "#41544B")


### PR DESCRIPTION
without this, selecting `kaolin-mono-dark` theme would fail with the following error message:
```let: Symbol’s value as variable is void: const```

Not sure if this is the best way to fix this, but it manage to solve the issue for me.