### PR TITLE
Adds avy support from kaolin-dark to all themes.

### DIFF
--- a/themes/kaolin-aurora-theme.el
+++ b/themes/kaolin-aurora-theme.el
@@ -132,7 +132,13 @@
    (org-table           (:foreground capri4))
    (org-code            (:foreground yellow3))
    (org-verbatim        (:inherit    'org-code))
-   (org-quote           (:foreground blue4)))
+   (org-quote           (:foreground blue4))
+
+   ;; Avy
+   (avy-lead-face   (:background red2 :foreground fg1))
+   (avy-lead-face-0 (:background spring-green4 :foreground fg1))
+   (avy-lead-face-1 (:background azure2 :foreground fg1))
+   (avy-lead-face-2 (:background magenta2 :foreground fg1)))
 
   (when kaolin-git-gutter-solid
     (custom-theme-set-faces

--- a/themes/kaolin-eclipse-theme.el
+++ b/themes/kaolin-eclipse-theme.el
@@ -96,7 +96,13 @@
    ;; TODO: change
    (org-code            (:foreground teal1))
    (org-verbatim        (:foreground amber3))
-   (org-quote           (:foreground magenta3)))
+   (org-quote           (:foreground magenta3))
+
+   ;; Avy
+   (avy-lead-face   (:background red2 :foreground fg1))
+   (avy-lead-face-0 (:background spring-green4 :foreground fg1))
+   (avy-lead-face-1 (:background azure2 :foreground fg1))
+   (avy-lead-face-2 (:background magenta2 :foreground fg1)))
 
   ;; Set custom vars
   (when kaolin-git-gutter-solid

--- a/themes/kaolin-galaxy-theme.el
+++ b/themes/kaolin-galaxy-theme.el
@@ -123,7 +123,13 @@
    (org-date            (:foreground spring-green3 :underline underline))
    (org-code            (:foreground erin3))
    (org-verbatim        (:foreground aquamarine3))
-   (org-quote           (:foreground blue9)))
+   (org-quote           (:foreground blue9))
+
+   ;; Avy
+   (avy-lead-face   (:background red2 :foreground fg1))
+   (avy-lead-face-0 (:background spring-green4 :foreground fg1))
+   (avy-lead-face-1 (:background azure2 :foreground fg1))
+   (avy-lead-face-2 (:background magenta2 :foreground fg1)))
 
   ;; Set custom vars
   (when kaolin-git-gutter-solid

--- a/themes/kaolin-mono-dark-theme.el
+++ b/themes/kaolin-mono-dark-theme.el
@@ -123,7 +123,13 @@
    (org-date            (:foreground spring-green3 :underline underline))
    (org-code            (:foreground vermilion4))
    (org-verbatim        (:foreground orange1))
-   (org-quote           (:foreground blue4)))
+   (org-quote           (:foreground blue4))
+
+   ;; Avy
+   (avy-lead-face   (:background red2 :foreground fg1))
+   (avy-lead-face-0 (:background spring-green4 :foreground fg1))
+   (avy-lead-face-1 (:background azure2 :foreground fg1))
+   (avy-lead-face-2 (:background magenta2 :foreground fg1)))
 
   (when kaolin-git-gutter-solid
     (custom-theme-set-faces

--- a/themes/kaolin-ocean-theme.el
+++ b/themes/kaolin-ocean-theme.el
@@ -97,7 +97,13 @@
 
    (git-gutter:added    (:background diff-add :foreground diff-add))
    (git-gutter:modified (:background diff-mod :foreground diff-mod))
-   (git-gutter:deleted  (:background diff-rem :foreground diff-rem)))
+   (git-gutter:deleted  (:background diff-rem :foreground diff-rem))
+
+   ;; Avy
+   (avy-lead-face   (:background red2 :foreground fg1))
+   (avy-lead-face-0 (:background spring-green4 :foreground fg1))
+   (avy-lead-face-1 (:background azure2 :foreground fg1))
+   (avy-lead-face-2 (:background magenta2 :foreground fg1)))
 
   ;; Set custom vars
   (when kaolin-git-gutter-solid

--- a/themes/kaolin-valley-dark-theme.el
+++ b/themes/kaolin-valley-dark-theme.el
@@ -131,7 +131,13 @@
    (org-level-4            (:foreground vermilion4 :bold nil))
    (org-code               (:foreground teal1))
    (org-verbatim           (:foreground orange2))
-   (org-table              (:foreground ultramarine4 :bold bold)))
+   (org-table              (:foreground ultramarine4 :bold bold))
+
+   ;; Avy
+   (avy-lead-face   (:background red2 :foreground fg1))
+   (avy-lead-face-0 (:background spring-green4 :foreground fg1))
+   (avy-lead-face-1 (:background azure2 :foreground fg1))
+   (avy-lead-face-2 (:background magenta2 :foreground fg1)))
 
   (when kaolin-git-gutter-solid
     (custom-theme-set-faces


### PR DESCRIPTION
Copied the avy custom theme set faces to all the dark varients, so the avy popups look very similar and don't fall back to default.