### PR TITLE
Solaire hl line

### DIFF
--- a/kaolin-themes-lib.el
+++ b/kaolin-themes-lib.el
@@ -1411,6 +1411,7 @@
 
     ;; Solaire mode
     (solaire-default-face       (:background pane))
+    (solaire-hl-line-face  (:inherit 'hl-line :background bg3))
 
     ;; Tuareg/OCaml
     (tuareg-font-double-colon-face            (:foreground warning))


### PR DESCRIPTION
Fixed this problem so `kaolin-themes-treemacs-hl-line` is not strictly needed.
Fixes #27 