### PR TITLE
Enumerate choices for comments styles

### DIFF
--- a/kaolin-themes.el
+++ b/kaolin-themes.el
@@ -118,7 +118,9 @@
 
 (defcustom kaolin-themes-comments-style 'normal
   "Sets the style of commentaries: normal which is used by default, alt to use colored commentary or contrast to make them more distinguished."
-  :options '(normal alt contrast)
+  :type '(choice (const :tag "Normal" normal)
+                 (const :tag "Colored" alt)
+                 (const :tag "Contrast" contrast))
   :group 'kaolin-themes)
 
 (defcustom kaolin-themes-git-gutter-solid nil


### PR DESCRIPTION
This PR changes how customization options for comments work to match what I've seen in other packages, where you enter a number to select from enumerated options:

![image](https://github.com/ogdenwebb/emacs-kaolin-themes/assets/9307830/5e4bcaaa-889e-492a-8e97-4b19d61685a3)

P.S. these themes are amazing! You have great taste!